### PR TITLE
Silently drop emitted events when flow is closed

### DIFF
--- a/Flow/Core/SharedFlow.lean
+++ b/Flow/Core/SharedFlow.lean
@@ -296,7 +296,7 @@ def create
 def emit (flow : MutableSharedFlow α) (value : α) : IO Unit :=
   flow.state.atomically do
     let state ← get
-    if state.isClosed then throw (IO.userError "Cannot emit to closed SharedFlow")
+    if state.isClosed then return
     for subscriber in state.subscribers do
       subscriber.enqueue value
     set (state.addToReplay value)

--- a/Flow/Core/SharedFlow.lean
+++ b/Flow/Core/SharedFlow.lean
@@ -284,6 +284,7 @@ def create
 /-- Emit a value to all current subscribers.
 
     Sends the value to each subscriber's channel for processing.
+    If the flow is closed, the value is silently dropped.
 
     Example:
     ```lean

--- a/FlowTest/Core/Index.lean
+++ b/FlowTest/Core/Index.lean
@@ -5,6 +5,7 @@ import FlowTest.Core.FilterTests
 import FlowTest.Core.BuildersTests
 import FlowTest.Core.SharedFlowTests
 import FlowTest.Core.StateFlowTests
+import FlowTest.Core.ProgramFlowTests
 
 namespace CoreTests
 
@@ -16,5 +17,6 @@ def allTests : List (String × IO Unit) :=
   ++ BuildersTests.allTests
   ++ SharedFlowTests.allTests
   ++ StateFlowTests.allTests
+  ++ ProgramFlowTests.allTests
 
 end CoreTests

--- a/FlowTest/Core/ProgramFlowTests.lean
+++ b/FlowTest/Core/ProgramFlowTests.lean
@@ -1,0 +1,68 @@
+import Flow
+import FlowTest.Assertions
+
+open Flow.Core Flow.Builders Flow.Internal
+
+instance : Flows.MergeableState Nat where
+  merge _ new _ := new
+  withEmptyAppendable s := s
+
+def runProgram (action : Program Unit Nat String α) : IO α := do
+  let (result, _) ← Program.run action () 0
+  match result with
+  | .ok a => pure a
+  | .error e => throw <| IO.userError s!"Program failed: {e}"
+
+namespace ProgramFlowTests
+
+def testClosePreventsNewEmissions : IO Unit := do
+  let flow ← runProgram <| ProgramFlow.create (ψ := Unit) (σ := Nat) (ε := String) (α := Nat)
+
+  let values ← IO.mkRef ([] : List Nat)
+  discard <| flow.subscribe fun v => do
+    match v with
+    | .ok n => values.modify (n :: ·)
+    | .error _ => pure ()
+
+  flow.emit 1
+  flow.underlying.flush
+  flow.close
+
+  let closed ← flow.isClosed
+  closed |> shouldEqual true
+
+  flow.emit 2
+
+  let vals ← values.get
+  vals |> shouldEqual [1]
+
+-- StateFlow.update calls value then emit. After close, emit silently drops,
+-- so update has no effect even though value still returns the last emitted value.
+def testUpdateAfterCloseIsNoOp : IO Unit := do
+  let flow ← MutableStateFlow.create (some 10)
+
+  let values ← IO.mkRef ([] : List Nat)
+  discard <| flow.subscribe fun v => do
+    values.modify (v :: ·)
+
+  flow.update (· + 1)
+  flow.flush
+  let v1 ← flow.value
+  v1 |> shouldBeSome 11
+
+  flow.close
+  flow.update (· + 100)
+
+  let vals ← values.get
+  vals |> shouldEqual [11, 10]
+
+  -- value still returns the last emitted value (replay cache is not cleared by close)
+  let v2 ← flow.value
+  v2 |> shouldBeSome 11
+
+def allTests : List (String × IO Unit) := [
+    ("ProgramFlow: close prevents new emissions", testClosePreventsNewEmissions),
+    ("StateFlow: update after close is no-op", testUpdateAfterCloseIsNoOp)
+  ]
+
+end ProgramFlowTests

--- a/FlowTest/Core/SharedFlowTests.lean
+++ b/FlowTest/Core/SharedFlowTests.lean
@@ -103,14 +103,7 @@ def testClosePreventsNewEmissions : IO Unit := do
   let closed ← flow.isClosed
   closed |> shouldEqual true
 
-  let errorThrown ← do
-    try
-      flow.emit 2
-      pure false
-    catch _ =>
-      pure true
-
-  errorThrown |> shouldEqual true
+  flow.emit 2
 
   let vals ← values.get
   vals |> shouldEqual [1]

--- a/FlowTest/Core/StateFlowTests.lean
+++ b/FlowTest/Core/StateFlowTests.lean
@@ -109,13 +109,7 @@ def testClosePreventsNewEmissions : IO Unit := do
   flow.close
   let closed ← flow.isClosed
   closed |> shouldEqual true
-  let errorThrown ← do
-    try
-      flow.emit 2
-      pure false
-    catch _ =>
-      pure true
-  errorThrown |> shouldEqual true
+  flow.emit 2
   (← values.get) |> shouldEqual [1, 0]
 
 def testToSharedFlowReceivesReplayAndNewEmissions : IO Unit := do

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,7 +2,7 @@ import Lake
 open Lake DSL
 
 package flow where
-  version := v!"0.3.0"
+  version := v!"0.3.1"
 
 @[default_target]
 lean_lib Flow where


### PR DESCRIPTION
Fixes #15

## Summary
- Change `emit` on a closed `SharedFlow` to silently return instead of throwing an error
- `StateFlow` and `ProgramFlow` inherit this behavior since they delegate to `SharedFlow.emit`
- Update tests to verify emit-after-close is a no-op rather than expecting an error

## Test plan
- [x] `make test` — all 57 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)