### PR TITLE
Flush before closing a flow

### DIFF
--- a/Flow/Core/SharedFlow.lean
+++ b/Flow/Core/SharedFlow.lean
@@ -314,7 +314,11 @@ def emitAll (flow : MutableSharedFlow α) (values : List α) : IO Unit := do
     flow.emit value
 
 /-- Close the flow, cancelling all subscribers and preventing new emissions and subscriptions.
-    Also cancels any child flows created via map/filter/filterMap. -/
+    Also cancels any child flows created via map/filter/filterMap.
+
+    **Known limitation:** Under concurrent access, emitters may enqueue new values between
+    the flush and the `isClosed` mutation. Those values will not be flushed before channels
+    are closed. -/
 def close (flow : MutableSharedFlow α) : IO Unit := do
   flow.flush
   let actions ← flow.state.atomically do

--- a/Flow/Core/SharedFlow.lean
+++ b/Flow/Core/SharedFlow.lean
@@ -316,6 +316,7 @@ def emitAll (flow : MutableSharedFlow α) (values : List α) : IO Unit := do
 /-- Close the flow, cancelling all subscribers and preventing new emissions and subscriptions.
     Also cancels any child flows created via map/filter/filterMap. -/
 def close (flow : MutableSharedFlow α) : IO Unit := do
+  flow.flush
   let actions ← flow.state.atomically do
     let state ← get
     set { state with isClosed := true, subscribers := #[], closeActions := #[] }

--- a/FlowTest/Core/SharedFlowTests.lean
+++ b/FlowTest/Core/SharedFlowTests.lean
@@ -343,6 +343,34 @@ def testCombineFlushCascadesToParents : IO Unit := do
   flow1.close
   flow2.close
 
+def testFlushBeforeClose : IO Unit := do
+  let flow ← MutableSharedFlow.create (α := Nat)
+
+  let values ← IO.mkRef ([] : List Nat)
+  discard <| flow.subscribe fun v => do
+    values.modify (v :: ·)
+
+  flow.emit 1
+  flow.emit 2
+  flow.emit 3
+  flow.close
+
+  (← values.get) |> shouldEqual [3, 2, 1]
+
+def testFlushBeforeCloseDerivedFlow : IO Unit := do
+  let parent ← MutableSharedFlow.create (α := Nat)
+  let child ← Flows.map parent (· * 2)
+
+  let childValues ← IO.mkRef ([] : List Nat)
+  discard <| child.subscribe fun v => do
+    childValues.modify (v :: ·)
+
+  parent.emit 5
+  parent.emit 10
+  parent.close
+
+  (← childValues.get) |> shouldEqual [20, 10]
+
 def allTests : List (String × IO Unit) := [
     ("SharedFlow: multiple consumers and cancellation", testMultipleConsumersAndCancellation),
     ("SharedFlow: replay buffer for new subscribers", testReplayBufferForNewSubscribers),
@@ -359,7 +387,9 @@ def allTests : List (String × IO Unit) := [
     ("SharedFlow: recursive cascading flush", testRecursiveCascadingFlush),
     ("SharedFlow: combine receives from both parents", testCombineReceivesFromBothParents),
     ("SharedFlow: combine close cascades from parent", testCombineCloseCascadesFromParent),
-    ("SharedFlow: combine flush cascades to parents", testCombineFlushCascadesToParents)
+    ("SharedFlow: combine flush cascades to parents", testCombineFlushCascadesToParents),
+    ("SharedFlow: flush before close", testFlushBeforeClose),
+    ("SharedFlow: flush before close derived flow", testFlushBeforeCloseDerivedFlow)
   ]
 
 end SharedFlowTests

--- a/FlowTest/Core/SharedFlowTests.lean
+++ b/FlowTest/Core/SharedFlowTests.lean
@@ -371,6 +371,11 @@ def testFlushBeforeCloseDerivedFlow : IO Unit := do
 
   (← childValues.get) |> shouldEqual [20, 10]
 
+  let parentClosed ← parent.isClosed
+  let childClosed ← child.isClosed
+  parentClosed |> shouldEqual true
+  childClosed |> shouldEqual true
+
 def allTests : List (String × IO Unit) := [
     ("SharedFlow: multiple consumers and cancellation", testMultipleConsumersAndCancellation),
     ("SharedFlow: replay buffer for new subscribers", testReplayBufferForNewSubscribers),

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,7 +2,7 @@ import Lake
 open Lake DSL
 
 package flow where
-  version := v!"0.3.1"
+  version := v!"0.3.2"
 
 @[default_target]
 lean_lib Flow where


### PR DESCRIPTION
Fixes #17

## Summary
- Call `flush` at the start of `MutableSharedFlow.close` so all buffered emissions are delivered to subscribers before the atomic state mutation that clears them
- The fix propagates naturally through derived flow chains since `closeActions` cascade child `close` calls, each of which also flushes before mutating

## Test plan
- [ ] `testFlushBeforeClose`: emit values without explicit flush, call `close`, verify all values received
- [ ] `testFlushBeforeCloseDerivedFlow`: emit to parent, close parent without explicit flush, verify mapped child subscriber received all values
- [ ] All existing tests pass: `make test`

🤖 Generated with [Claude Code](https://claude.com/claude-code)