### PR TITLE
chore: bump toolchain to v4.29.0

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,7 +2,7 @@ import Lake
 open Lake DSL
 
 package flow where
-  version := v!"0.3.2"
+  version := v!"0.3.3"
 
 @[default_target]
 lean_lib Flow where

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.28.0
+leanprover/lean4:v4.29.0


### PR DESCRIPTION
## Summary
- Bump lean-toolchain from v4.28.0 to v4.29.0
- Builds cleanly with no errors or warnings

Needed for predictable-code toolchain upgrade to use Batteries' `DecidableEq (Except)` instance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)