### PR TITLE
chore: upgrade to Lean 4.32.0

### DIFF
--- a/lakefile.lean
+++ b/lakefile.lean
@@ -2,7 +2,7 @@ import Lake
 open Lake DSL
 
 package flow where
-  version := v!"0.3.4"
+  version := v!"0.3.5"
 
 @[default_target]
 lean_lib Flow where

--- a/lean-toolchain
+++ b/lean-toolchain
@@ -1,1 +1,1 @@
-leanprover/lean4:v4.30.0
+leanprover/lean4:v4.32.0


### PR DESCRIPTION
Upgrades lean4-flow to Lean 4.32.0 and cuts the next patch release.

## Summary
- **Toolchain**: bumped `lean-toolchain` from `v4.30.0` to `v4.32.0`.
- **Release**: bumped the package `version` to `0.3.5` (auto-tag cuts `v0.3.5` on merge).
- **Verification**: builds clean with zero warnings under 4.32 and all 61 tests pass; leaf package, no source changes required.